### PR TITLE
Fix incorrect mapping prop type (function, not object)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -431,7 +431,7 @@ Formsy.propTypes = {
   isRequired: PropTypes.func,
   isValid: PropTypes.func,
   isValidValue: PropTypes.func,
-  mapping: PropTypes.object, // eslint-disable-line
+  mapping: PropTypes.func,
   preventExternalInvalidation: PropTypes.bool,
   onChange: PropTypes.func,
   onInvalid: PropTypes.func,


### PR DESCRIPTION
Example of use as function: https://github.com/formsy/formsy-react/blob/master/src/index.js#L122