### PR TITLE
Fix email validation, broken for new longer domains

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -459,6 +459,7 @@ const addValidationRule = (name, func) => {
 const withFormsy = Wrapper;
 
 const deprecatedWrapper = (Component) => {
+  // eslint-disable-next-line no-console
   console.warn('Wrapper has been renamed to withFormsy. Importing Wrapper from formsy-react is depreacted and will be removed in the future. Please rename your Wrapper imports to withFormsy.');
 
   return withFormsy(Component);

--- a/src/validationRules.js
+++ b/src/validationRules.js
@@ -18,7 +18,8 @@ const validations = {
     return isEmpty(value);
   },
   isEmail(values, value) {
-    return validations.matchRegexp(values, value, /^([\w-]+(?:\.[\w-]+)*)@((?:[\w-]+\.)*\w[\w-]{0,66})\.([a-z]{2,6}(?:\.[a-z]{2})?)$/i);
+    // Regex from http://emailregex.com/
+    return validations.matchRegexp(values, value, /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/i);
   },
   isUrl(values, value) {
     return validations.matchRegexp(values, value, /^(?:\w+:)?\/\/([^\s.]+\.\S{2}|localhost[:?\d]*)\S*$/i);

--- a/tests/Rules-isEmail-spec.js
+++ b/tests/Rules-isEmail-spec.js
@@ -49,6 +49,15 @@ export default {
 
   },
 
+  'should pass with new long domains': function (test) {
+
+    const form = TestUtils.renderIntoDocument(<TestForm inputValue="tickets@now.diamonds"/>);
+    const inputComponent = TestUtils.findRenderedComponentWithType(form, TestInput);
+    test.equal(inputComponent.isValid(), true);
+    test.done();
+
+  },
+
   'should pass with an undefined': function (test) {
 
     const form = TestUtils.renderIntoDocument(<TestForm inputValue={undefined}/>);


### PR DESCRIPTION
With only test:

![image](https://user-images.githubusercontent.com/796717/32913766-508d2d82-cae1-11e7-95ec-f2b08c2af7bf.png)

I would also be fine with us switching to an extremely simple regex, like so: https://github.com/plataformatec/devise/blob/18b6064d74726147eccd69b24812000074261bbb/lib/generators/templates/devise.rb#L151-L154