### PR TITLE
refactor(Wrapper) Use arrow functions instead of manual bind

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,4 @@
 {
+  "parser": "babel-eslint",
   "extends": "airbnb"
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",
+    "babel-eslint": "^8.0.2",
     "babel-loader": "^7.1.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-react": "^6.24.1",

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -106,13 +106,17 @@ export default (Component) => {
     }
 
     getErrorMessages = () => {
-      return !this.isValid() || this.showRequired() ?
-        (this.state.externalError || this.state.validationError || []) : [];
+      if (!this.isValid() || this.showRequired()) {
+        return this.state.externalError || this.state.validationError || [];
+      }
+
+      return [];
+
+      // !this.isValid() || this.showRequired() ?
+      // (this.state.externalError || this.state.validationError || []) : [];
     }
 
-    getValue = () => {
-      return this.state.value;
-    }
+    getValue = () => this.state.value;
 
     setValidations = (validations, required) => {
       // Add validations to the store itself as the props object can not be modified
@@ -138,34 +142,21 @@ export default (Component) => {
       }
     }
 
-    hasValue = () => {
-      return this.state.value !== '';
-    }
+    hasValue = () => this.state.value !== '';
 
-    isFormDisabled = () => {
-      return this.context.formsy.isFormDisabled();
-    }
+    isFormDisabled = () => this.context.formsy.isFormDisabled();
 
-    isFormSubmitted = () => {
-      return this.state.formSubmitted;
-    }
+    isFormSubmitted = () => this.state.formSubmitted;
 
-    isPristine = () => {
-      return this.state.isPristine;
-    }
+    isPristine = () => this.state.isPristine;
 
-    isRequired = () => {
-      return !!this.props.required;
-    }
+    isRequired = () => !!this.props.required;
 
-    isValid = () => {
-      return this.state.isValid;
-    }
+    isValid = () => this.state.isValid;
 
-    isValidValue = (value) => {
-      return this.context.formsy.isValidValue.call(null, this, value);
+    isValidValue = value =>
+      this.context.formsy.isValidValue.call(null, this, value);
       // return this.props.isValidValue.call(null, this, value);
-    }
 
     resetValue = () => {
       this.setState({
@@ -176,13 +167,9 @@ export default (Component) => {
       });
     }
 
-    showError = () => {
-      return !this.showRequired() && !this.isValid();
-    }
+    showError = () => !this.showRequired() && !this.isValid();
 
-    showRequired = () => {
-      return this.state.isRequired;
-    }
+    showRequired = () => this.state.isRequired;
 
     render() {
       const { innerRef } = this.props;

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -59,22 +59,6 @@ export default (Component) => {
         externalError: null,
         formSubmitted: false,
       };
-
-      this.getErrorMessage = this.getErrorMessage.bind(this);
-      this.getErrorMessages = this.getErrorMessages.bind(this);
-      this.getValue = this.getValue.bind(this);
-      this.hasValue = this.hasValue.bind(this);
-      this.isFormDisabled = this.isFormDisabled.bind(this);
-      this.isPristine = this.isPristine.bind(this);
-      this.isFormSubmitted = this.isFormSubmitted.bind(this);
-      this.isRequired = this.isRequired.bind(this);
-      this.isValidValue = this.isValidValue.bind(this);
-      this.isValid = this.isValid.bind(this);
-      this.resetValue = this.resetValue.bind(this);
-      this.setValidations = this.setValidations.bind(this);
-      this.setValue = this.setValue.bind(this);
-      this.showRequired = this.showRequired.bind(this);
-      this.showError = this.showError.bind(this);
     }
 
     componentWillMount() {
@@ -116,21 +100,21 @@ export default (Component) => {
       this.context.formsy.detachFromForm(this);
     }
 
-    getErrorMessage() {
+    getErrorMessage = () => {
       const messages = this.getErrorMessages();
       return messages.length ? messages[0] : null;
     }
 
-    getErrorMessages() {
+    getErrorMessages = () => {
       return !this.isValid() || this.showRequired() ?
         (this.state.externalError || this.state.validationError || []) : [];
     }
 
-    getValue() {
+    getValue = () => {
       return this.state.value;
     }
 
-    setValidations(validations, required) {
+    setValidations = (validations, required) => {
       // Add validations to the store itself as the props object can not be modified
       this.validations = convertValidationsToObject(validations) || {};
       this.requiredValidations = required === true ? { isDefaultRequiredValue: true } :
@@ -139,7 +123,7 @@ export default (Component) => {
 
     // By default, we validate after the value has been set.
     // A user can override this and pass a second parameter of `false` to skip validation.
-    setValue(value, validate = true) {
+    setValue = (value, validate = true) => {
       if (!validate) {
         this.setState({
           value,
@@ -154,36 +138,36 @@ export default (Component) => {
       }
     }
 
-    hasValue() {
+    hasValue = () => {
       return this.state.value !== '';
     }
 
-    isFormDisabled() {
+    isFormDisabled = () => {
       return this.context.formsy.isFormDisabled();
     }
 
-    isFormSubmitted() {
+    isFormSubmitted = () => {
       return this.state.formSubmitted;
     }
 
-    isPristine() {
+    isPristine = () => {
       return this.state.isPristine;
     }
 
-    isRequired() {
+    isRequired = () => {
       return !!this.props.required;
     }
 
-    isValid() {
+    isValid = () => {
       return this.state.isValid;
     }
 
-    isValidValue(value) {
+    isValidValue = (value) => {
       return this.context.formsy.isValidValue.call(null, this, value);
       // return this.props.isValidValue.call(null, this, value);
     }
 
-    resetValue() {
+    resetValue = () => {
       this.setState({
         value: this.state.pristineValue,
         isPristine: true,
@@ -192,11 +176,11 @@ export default (Component) => {
       });
     }
 
-    showError() {
+    showError = () => {
       return !this.showRequired() && !this.isValid();
     }
 
-    showRequired() {
+    showRequired = () => {
       return this.state.isRequired;
     }
 

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -109,11 +109,7 @@ export default (Component) => {
       if (!this.isValid() || this.showRequired()) {
         return this.state.externalError || this.state.validationError || [];
       }
-
       return [];
-
-      // !this.isValid() || this.showRequired() ?
-      // (this.state.externalError || this.state.validationError || []) : [];
     }
 
     getValue = () => this.state.value;
@@ -156,7 +152,6 @@ export default (Component) => {
 
     isValidValue = value =>
       this.context.formsy.isValidValue.call(null, this, value);
-      // return this.props.isValidValue.call(null, this, value);
 
     resetValue = () => {
       this.setState({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,58 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@7.0.0-beta.32", "@babel/code-frame@^7.0.0-beta.31":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.32.tgz#04f231b8ec70370df830d9926ce0f5add074ec4c"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
+"@babel/helper-function-name@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.32.tgz#6161af4419f1b4e3ed2d28c0c79c160e218be1f3"
+  dependencies:
+    "@babel/helper-get-function-arity" "7.0.0-beta.32"
+    "@babel/template" "7.0.0-beta.32"
+    "@babel/types" "7.0.0-beta.32"
+
+"@babel/helper-get-function-arity@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.32.tgz#93721a99db3757de575a83bab7c453299abca568"
+  dependencies:
+    "@babel/types" "7.0.0-beta.32"
+
+"@babel/template@7.0.0-beta.32":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.32.tgz#e1d9fdbd2a7bcf128f2f920744a67dab18072495"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.32"
+    "@babel/types" "7.0.0-beta.32"
+    babylon "7.0.0-beta.32"
+    lodash "^4.2.0"
+
+"@babel/traverse@^7.0.0-beta.31":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.32.tgz#b78b754c6e1af3360626183738e4c7a05951bc99"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.32"
+    "@babel/helper-function-name" "7.0.0-beta.32"
+    "@babel/types" "7.0.0-beta.32"
+    babylon "7.0.0-beta.32"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
+
+"@babel/types@7.0.0-beta.32", "@babel/types@^7.0.0-beta.31":
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.32.tgz#c317d0ecc89297b80bbcb2f50608e31f6452a5ff"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 "@types/node@*":
   version "6.0.92"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.92.tgz#e7f721ae282772e12ba2579968c00d9cce422c5d"
@@ -326,6 +378,15 @@ babel-core@^6.26.0:
     private "^0.1.7"
     slash "^1.0.0"
     source-map "^0.5.6"
+
+babel-eslint@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.2.tgz#e44fb9a037d749486071d52d65312f5c20aa7530"
+  dependencies:
+    "@babel/code-frame" "^7.0.0-beta.31"
+    "@babel/traverse" "^7.0.0-beta.31"
+    "@babel/types" "^7.0.0-beta.31"
+    babylon "^7.0.0-beta.31"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.0"
@@ -916,6 +977,10 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babylon@7.0.0-beta.32, babylon@^7.0.0-beta.31:
+  version "7.0.0-beta.32"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.32.tgz#e9033cb077f64d6895f4125968b37dc0a8c3bc6e"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -2389,6 +2454,10 @@ glob@^7.0.0, glob@^7.0.3, glob@^7.0.5, glob@^7.0.6, glob@^7.1.2:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
+globals@^10.0.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
+
 globals@^9.17.0, globals@^9.18.0:
   version "9.18.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-9.18.0.tgz#aa3896b3e69b487f17e31ed2143d69a8e30c2d8a"
@@ -2705,7 +2774,7 @@ interpret@^1.0.0:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.4.tgz#820cdd588b868ffb191a809506d6c9c8f212b1b0"
 
-invariant@^2.2.2:
+invariant@^2.2.0, invariant@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:
@@ -3192,7 +3261,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.3.0:
+lodash@^4.13.1, lodash@^4.14.0, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.2.0, lodash@^4.3.0:
   version "4.17.4"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.4.tgz#78203a4d1c328ae1d86dca6460e369b57f4055ae"
 
@@ -4891,6 +4960,10 @@ to-arraybuffer@^1.0.0:
 to-fast-properties@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-1.0.3.tgz#b83571fa4d8c25b82e231b06e3a3055de4ca1a47"
+
+to-fast-properties@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.3, tough-cookie@~2.3.0, tough-cookie@~2.3.3:
   version "2.3.3"


### PR DESCRIPTION
I refactored the Wrapper to use arrow functions instead of  binding manually as suggested in https://github.com/formsy/formsy-react/pull/22#issuecomment-345279191 I really think this (or #22) should be released asap as the Wrapper is not usable right now.

Oh and thanks for all the work you're doing to get this project back into shape. :+1: 