### PR TITLE
Allow string values for Wrapper `required` prop

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -35,7 +35,10 @@ const convertValidationsToObject = (validations) => {
 const propTypes = {
   innerRef: PropTypes.func,
   name: PropTypes.string.isRequired,
-  required: PropTypes.bool,
+  required: PropTypes.oneOfType([
+    PropTypes.bool,
+    PropTypes.string,
+  ]),
   validations: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,


### PR DESCRIPTION
As per documentation (https://github.com/christianalfoni/formsy-react/blob/master/API.md#required) `required` prop should accept rule name, not just boolean value.
