### PR TITLE
pass nativeProps to wrapped component

### DIFF
--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -40,6 +40,8 @@ const propTypes = {
     PropTypes.object,
     PropTypes.string,
   ]),
+  validationError: PropTypes.string,
+  validationErrors: PropTypes.object, // eslint-disable-line react/forbid-prop-types
   validations: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.string,
@@ -173,7 +175,13 @@ export default (Component) => {
     showRequired = () => this.state.isRequired;
 
     render() {
-      const { innerRef } = this.props;
+      const {
+        innerRef,
+        validations,
+        validationError,
+        validationErrors,
+        ...nativeProps
+      } = this.props;
       const propsForElement = {
         getErrorMessage: this.getErrorMessage,
         getErrorMessages: this.getErrorMessages,
@@ -190,6 +198,7 @@ export default (Component) => {
         setValue: this.setValue,
         showRequired: this.showRequired,
         showError: this.showError,
+        nativeProps,
         ...this.props,
       };
 


### PR DESCRIPTION
Make possible to get native props like `style`, `className`, `placeholder`, `onBlur` etc... without wrap theses native props into a specific prop.

```js
class MyInput extends React.Component {
  ...
  render() {
    const { nativeProps } = this.props;
    return (
      <input
        {...nativeProps}
        onChange={this.changeValue}
        value={this.props.getValue() || ''}
      />
    )
  }
}

export default withFormsy(MyInput);
```

Before:
```js
<MyInput
  name="email"
  validations="isEmail"
  validationError="This is not a valid email"
  nativeProps={{
    style: { padding: 20 },
    placeholder: "Enter your email",  
  }}
/>
```

After:

```js
<MyInput
  name="email"
  validations="isEmail"
  validationError="This is not a valid email"
  placeholder="Enter your email"
  style={{ padding: 20 }}
/>
```

I had to add `validationError` and `validationErrors` in propTypes for ESLint 