### PR TITLE
fix: Scroll in IE does not work if form is disabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -373,6 +373,7 @@ class Formsy extends React.Component {
         onReset: this.resetInternal,
         onSubmit: this.submit,
         ...nonFormsyProps,
+        disabled: false,
       },
       this.props.children,
     );


### PR DESCRIPTION
Remove disabled attribute from form