### PR TITLE
Fix `isDefaultRequiredValue` to also consider `null` as an empty value.

### DIFF
--- a/src/validationRules.js
+++ b/src/validationRules.js
@@ -3,7 +3,7 @@ const isEmpty = value => value === '';
 
 const validations = {
   isDefaultRequiredValue(values, value) {
-    return value === undefined || value === '';
+    return value === undefined || value === null || value === '';
   },
   isExisty(values, value) {
     return isExisty(value);

--- a/tests/Validation-spec.js
+++ b/tests/Validation-spec.js
@@ -103,6 +103,23 @@ export default {
 
   },
 
+  'should trigger the `onInvalid` handler if a required element receives `null` as the value': function (test) {
+
+    const onValid = sinon.spy();
+    const onInvalid = sinon.spy();
+
+    TestUtils.renderIntoDocument(
+      <Formsy onValid={onValid} onInvalid={onInvalid}>
+        <FormsyTest value={null} name="foo" required />
+      </Formsy>
+    );
+
+    test.equal(onValid.called, false);
+    test.equal(onInvalid.called, true);
+    test.done();
+
+  },
+
   'should be able to use provided validate function': function (test) {
 
     let isValid = false;


### PR DESCRIPTION
I guess `isDefaultRequiredValue` should also consider `null` as an empty value, if also an empty string is considered empty.

This has confused my quite a bit coming from a scenario similar to the test I added.