### PR TITLE
test that element's sCU is called with correct value

### DIFF
--- a/tests/Element-spec.js
+++ b/tests/Element-spec.js
@@ -607,6 +607,38 @@ export default {
 
   },
 
+  'input should call shouldComponentUpdate with correct value': function (test) {
+
+    var renderSpy = sinon.spy();
+
+    const Input = InputFactory({
+      shouldComponentUpdate: function(prevProps) {
+        return prevProps.value !== this.props.value
+       },
+       render: function() {
+        renderSpy();
+        return <input type={this.props.type} value={this.props.value} onChange={this.updateValue}/>;
+      }
+    });
+
+    const form = TestUtils.renderIntoDocument(
+      <Formsy>
+        <Input name="foo" value="foo"/>
+      </Formsy>
+    );
+
+    const input = TestUtils.findRenderedDOMComponentWithTag(form, 'INPUT');
+
+    test.equal(renderSpy.calledOnce, true);
+
+    TestUtils.Simulate.change(input, {target: {value: 'fooz'}});
+    test.equal(input.value, 'fooz');
+    test.equal(renderSpy.calledTwice, true);
+
+    test.done();
+
+  },
+
   'binds all necessary methods': function (test) {
     const onInputRef = input => {
       [


### PR DESCRIPTION
I've noticed that an Element's `shouldComponentUpdate` is called with incorrect values in version 1 but version 2.x solved it. My guess is changing from `props.getValue()` to `props.value`. Anyway, since I added a test to check it out I decided to open this PR.

See https://codesandbox.io/s/k555wyyx5v for reproduction case on version 1.x

It would be really awesome if version 2 changes were released as soon as possible since this issue actually blocks from optimizing the form fields with sCU.