### PR TITLE
Wrapper: don't supply a default value for innerRef prop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules
 .DS_Store
 .idea
+yarn-error.log*
+yarn-debug.log*
+npm-error.log*

--- a/lib/Wrapper.js
+++ b/lib/Wrapper.js
@@ -272,7 +272,6 @@ exports.default = function (Component) {
   };
 
   WrappedComponent.defaultProps = {
-    innerRef: function innerRef() {},
     required: false,
     validationError: '',
     validationErrors: {},

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -216,7 +216,7 @@ export default (Component) => {
   };
 
   WrappedComponent.defaultProps = {
-    innerRef: () => {},
+    innerRef: undefined,
     required: false,
     validationError: '',
     validationErrors: {},


### PR DESCRIPTION
This is primarily to avoid invalid usage of refs when wrapping
stateless functional components with the formsy HOC.