### PR TITLE
Fix: Improve comparison of dates in isSame

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -34,6 +34,8 @@ export default {
       return !this.arraysDiffer(a, b);
     } else if (typeof a === 'function') {
       return a.toString() === b.toString();
+    } else if (a !== null && b !== null && a instanceof Date && b instanceof Date) {
+      return a.toString() === b.toString();
     } else if (typeof a === 'object' && a !== null && b !== null) {
       return !this.objectsDiffer(a, b);
     }


### PR DESCRIPTION
If object data type is date, function "isSame" does not work as expected.