### PR TITLE
fix: Revert prop override change made in 2.x branch

### DIFF
--- a/lib/Wrapper.js
+++ b/lib/Wrapper.js
@@ -232,7 +232,7 @@ exports.default = function (Component) {
       value: function render() {
         var innerRef = this.props.innerRef;
 
-        var propsForElement = _extends({}, this.props, {
+        var propsForElement = _extends({
           errorMessage: this.getErrorMessage(),
           errorMessages: this.getErrorMessages(),
           hasValue: this.hasValue(),
@@ -248,7 +248,7 @@ exports.default = function (Component) {
           showError: this.showError(),
           showRequired: this.showRequired(),
           value: this.getValue()
-        });
+        }, this.props);
 
         if (innerRef) {
           propsForElement.ref = innerRef;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,6 +44,8 @@ exports.default = {
       return !this.arraysDiffer(a, b);
     } else if (typeof a === 'function') {
       return a.toString() === b.toString();
+    } else if (a !== null && b !== null && a instanceof Date && b instanceof Date) {
+      return a.toString() === b.toString();
     } else if ((typeof a === 'undefined' ? 'undefined' : _typeof(a)) === 'object' && a !== null && b !== null) {
       return !this.objectsDiffer(a, b);
     }

--- a/src/Wrapper.js
+++ b/src/Wrapper.js
@@ -175,7 +175,6 @@ export default (Component) => {
     render() {
       const { innerRef } = this.props;
       const propsForElement = {
-        ...this.props,
         errorMessage: this.getErrorMessage(),
         errorMessages: this.getErrorMessages(),
         hasValue: this.hasValue(),
@@ -191,6 +190,7 @@ export default (Component) => {
         showError: this.showError(),
         showRequired: this.showRequired(),
         value: this.getValue(),
+        ...this.props,
       };
 
       if (innerRef) {


### PR DESCRIPTION
# Description

Reverts minor change in https://github.com/formsy/formsy-react/pull/50

In Formsy 1.x, `...props` could override any Formsy props. This was changed in 2.x, and has had a lot more ramifications on codebases than I expected. Not totally sure we should revert but it's worth considering.

# Checklist

- [x] PR title follows [title guidelines](https://github.com/formsy/formsy-react#pr-titles--commits)
