### PR TITLE
Allow HTMLFormElement attributes to be passed to a Formsy form

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,8 +8,10 @@ import Wrapper, { propTypes } from './Wrapper';
 
 import { IData, IModel, InputComponent, IResetModel, IUpdateInputsWithError, ValidationFunction } from './interfaces';
 
+interface FormHTMLAttributesCleaned extends Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onChange' | 'onSubmit'> {}
+
 /* eslint-disable react/no-unused-state, react/default-props-match-prop-types */
-export interface FormsyProps {
+export interface FormsyProps extends FormHTMLAttributesCleaned {
   disabled: boolean;
   getErrorMessage: any;
   getErrorMessages: any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import Wrapper, { propTypes } from './Wrapper';
 
 import { IData, IModel, InputComponent, IResetModel, IUpdateInputsWithError, ValidationFunction } from './interfaces';
 
-interface FormHTMLAttributesCleaned extends Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onChange' | 'onSubmit'> {}
+type FormHTMLAttributesCleaned = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onChange' | 'onSubmit'>;
 
 /* eslint-disable react/no-unused-state, react/default-props-match-prop-types */
 export interface FormsyProps extends FormHTMLAttributesCleaned {


### PR DESCRIPTION
# Allow HTMLFormElement attributes to be passed to a Formsy form

This fixes a use case where I wanted to set a `class` attribute on the `<form />` output by Formsy. 

This works fine at runtime (it is passed through in `nonFormsyProps`), however passing a `className` prop is not allowed in the `FormsyProps` definition.

This PR expands the `FormsyProps` definition to explicitly allow passing HTMLFormElement attributes that are passed through (`nonFormsyProps`) to the `<form />`.