### PR TITLE
Fix shouldComponentUpdate and context changes in `withFormsy`

### DIFF
--- a/__test_utils__/TestInput.tsx
+++ b/__test_utils__/TestInput.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withFormsy } from './..';
+import { withFormsy } from '../src';
 import { PassDownProps } from '../src/Wrapper';
 
 class TestInput extends React.Component<React.HTMLProps<HTMLInputElement>> {

--- a/__test_utils__/TestInputHoc.tsx
+++ b/__test_utils__/TestInputHoc.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { withFormsy } from './..';
+import { withFormsy } from '../src';
 
 class TestComponent extends React.Component {
   render() {

--- a/src/Wrapper.ts
+++ b/src/Wrapper.ts
@@ -164,14 +164,19 @@ export default function<Props, State, CompState>(
       this.setValidations(nextProps.validations, nextProps.required);
     }
 
-    public shouldComponentUpdate(nextProps, nextState) {
-      // eslint-disable-next-line react/destructuring-assignment
-      const isPropsChanged = Object.keys(this.props).some(k => this.props[k] !== nextProps[k]);
+    public shouldComponentUpdate(nextProps, nextState, nextContext) {
+      const {
+        props,
+        state,
+        context: { formsy: formsyContext },
+      } = this;
+      const isPropsChanged = Object.keys(props).some(k => props[k] !== nextProps[k]);
 
-      // eslint-disable-next-line react/destructuring-assignment
-      const isStateChanged = Object.keys(this.state).some(k => this.state[k] !== nextState[k]);
+      const isStateChanged = Object.keys(state).some(k => state[k] !== nextState[k]);
 
-      return isPropsChanged || isStateChanged;
+      const isFormsyContextChanged = Object.keys(formsyContext).some(k => formsyContext[k] !== nextContext.formsy[k]);
+
+      return isPropsChanged || isStateChanged || isFormsyContextChanged;
     }
 
     public componentDidUpdate(prevProps) {
@@ -246,7 +251,7 @@ export default function<Props, State, CompState>(
     public hasValue = () => this.state.value !== '';
 
     // eslint-disable-next-line react/destructuring-assignment
-    public isFormDisabled = () => this.context.formsy.isFormDisabled();
+    public isFormDisabled = () => this.context.formsy.isFormDisabled;
 
     // eslint-disable-next-line react/destructuring-assignment
     public isFormSubmitted = () => this.state.formSubmitted;

--- a/src/index.ts
+++ b/src/index.ts
@@ -136,8 +136,8 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
     formsy: {
       attachToForm: this.attachToForm,
       detachFromForm: this.detachFromForm,
-      isFormDisabled: this.isFormDisabled,
-      isValidValue: (component, value) => this.runValidation(component, value).isValid,
+      isFormDisabled: this.isFormDisabled(),
+      isValidValue: this.isValidValue,
       validate: this.validate,
     },
   });
@@ -232,6 +232,8 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
       onInvalid();
     }
   };
+
+  public isValidValue = (component, value) => this.runValidation(component, value).isValid;
 
   // eslint-disable-next-line react/destructuring-assignment
   public isFormDisabled = () => this.props.disabled;


### PR DESCRIPTION
`shouldComponentUpdate` in the `withFormsy` hoc was not taking into account
changes applied in the context.

This fixes a situation where changes to the `disabled` prop in the form were
being prevented from rendering in the form’s child components.

To more easily check whether the formsy context had changed the following
changes to the formsy context have been made:

- `context.fomsy.isValidValue` is now bound to `this`, previously a new
  function was being re-created on each `getChildContext` call, triggering
  excess changes on the context.
- `isFormDisabled` is now stored as a boolean value.
