### PR TITLE
Remove deprecated lifecycle methods.

### DIFF
--- a/__tests__/Element-spec.tsx
+++ b/__tests__/Element-spec.tsx
@@ -49,7 +49,7 @@ describe('Element', () => {
   it('should set back to pristine value when running reset', () => {
     let reset = null;
     const Input = InputFactory({
-      componentDidMount() {
+      componentDidUpdate() {
         reset = this.props.resetValue;
       },
     });
@@ -68,7 +68,7 @@ describe('Element', () => {
   it('should return error message passed when calling getErrorMessage()', () => {
     let errorMessage = null;
     const Input = InputFactory({
-      componentDidMount() {
+      componentDidUpdate() {
         errorMessage = this.props.errorMessage;
       },
     });
@@ -103,7 +103,7 @@ describe('Element', () => {
   it('should return true or false when calling isRequired() depending on passed required attribute', () => {
     const isRequireds = [];
     const Input = InputFactory({
-      componentDidMount() {
+      componentDidUpdate() {
         isRequireds.push(this.props.isRequired);
       },
     });
@@ -123,7 +123,7 @@ describe('Element', () => {
   it('should return true or false when calling showRequired() depending on input being empty and required is passed, or not', () => {
     const showRequireds = [];
     const Input = InputFactory({
-      componentDidMount() {
+      componentDidUpdate() {
         showRequireds.push(this.props.showRequired);
       },
     });

--- a/src/Wrapper.ts
+++ b/src/Wrapper.ts
@@ -141,27 +141,18 @@ export default function<Props, State, CompState>(
       };
     }
 
-    public componentWillMount() {
+    public componentDidMount() {
       const { validations, required, name } = this.props;
       const { formsy } = this.context;
-
-      const configure = () => {
-        this.setValidations(validations, required);
-
-        // Pass a function instead?
-        formsy.attachToForm(this);
-      };
 
       if (!name) {
         throw new Error('Form Input requires a name property when used');
       }
 
-      configure();
-    }
+      this.setValidations(validations, required);
 
-    // We have to make sure the validate method is kept when new props are added
-    public componentWillReceiveProps(nextProps) {
-      this.setValidations(nextProps.validations, nextProps.required);
+      // Pass a function instead?
+      formsy.attachToForm(this);
     }
 
     public shouldComponentUpdate(nextProps, nextState, nextContext) {
@@ -191,12 +182,14 @@ export default function<Props, State, CompState>(
 
       // If validations or required is changed, run a new validation
       if (!utils.isSame(validations, prevProps.validations) || !utils.isSame(required, prevProps.required)) {
+        this.setValidations(validations, required);
         formsy.validate(this);
       }
     }
 
     // Detach it when component unmounts
-    public componentWillUnmount() {
+    // eslint-disable-next-line react/sort-comp
+    public componentDidUnmount() {
       const { formsy } = this.context;
       formsy.detachFromForm(this);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -151,13 +151,8 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
   });
 
   public componentDidMount = () => {
-    this.validateForm();
-  };
-
-  public componentWillUpdate = () => {
-    // Keep a reference to input names before form updates,
-    // to check if inputs has changed after render
     this.prevInputNames = this.inputs.map(component => component.props.name);
+    this.validateForm();
   };
 
   public componentDidUpdate = () => {
@@ -169,6 +164,7 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
 
     const newInputNames = this.inputs.map(component => component.props.name);
     if (this.prevInputNames && utils.arraysDiffer(this.prevInputNames, newInputNames)) {
+      this.prevInputNames = newInputNames;
       this.validateForm();
     }
   };


### PR DESCRIPTION
# Description

Here's a shot at getting rid of the deprecated react lifecycle methods
https://github.com/formsy/formsy-react/issues/213

There's one potentially breaking change. Because the wrapper now uses `componentDidMount`, the wrapped components `componentDidMount` runs first. If a wrapped component depends on validation errors being populated in `componentDidMount`, it will now break.
