### PR TITLE
Fix wrapper unregister on unmount.

### DIFF
--- a/__tests__/Element-spec.tsx
+++ b/__tests__/Element-spec.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import sinon from 'sinon';
 import { mount } from 'enzyme';
-
 import Formsy, { withFormsy } from '../src';
 import immediate from '../__test_utils__/immediate';
 import TestInput, { InputFactory } from '../__test_utils__/TestInput';
@@ -607,5 +606,18 @@ describe('Element', () => {
         <TestInput ref={onInputRef} name="name" value="foo" />
       </Formsy>,
     );
+  });
+
+  it('unregisters on unmount', () => {
+    const TestComponent = ({ hasInput }) => <Formsy>{hasInput ? <TestInput name="foo" value="foo" /> : null}</Formsy>;
+
+    const wrapper = mount(<TestComponent hasInput />);
+    const formsy = wrapper.find(Formsy).instance();
+
+    expect(formsy.inputs).toHaveLength(1);
+
+    wrapper.setProps({ hasInput: false });
+
+    expect(formsy.inputs).toHaveLength(0);
   });
 });

--- a/src/Wrapper.ts
+++ b/src/Wrapper.ts
@@ -185,7 +185,7 @@ export default function<T>(
 
     // Detach it when component unmounts
     // eslint-disable-next-line react/sort-comp
-    public componentDidUnmount() {
+    public componentWillUnmount() {
       const { formsy } = this.context;
       formsy.detachFromForm(this);
     }


### PR DESCRIPTION
Resolves https://github.com/formsy/formsy-react/issues/261

- Fixes typo of `componentDidUnmount` to `componentWillUnmount`
- Adds a failing test that is fixed by this pr
