### PR TITLE
Fix deprecated lifecycle method usage in tests

### DIFF
--- a/__test_utils__/DynamicInputForm.tsx
+++ b/__test_utils__/DynamicInputForm.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import Formsy from '../src';
+import TestInput from './TestInput';
+
+interface DynamicInputFormProps {
+  onSubmit: (model: any) => void;
+  inputName?: string;
+}
+
+class DynamicInputForm extends React.Component<DynamicInputFormProps> {
+  public state = {
+    input: null,
+  };
+
+  private addInput = () => {
+    const { inputName } = this.props;
+    this.setState({
+      input: <TestInput name={inputName} value="" />,
+    });
+  };
+
+  public render() {
+    return (
+      <>
+        <Formsy onSubmit={this.props.onSubmit}>
+          {this.state.input}
+          {this.props.children}
+        </Formsy>
+        <button type="button" onClick={this.addInput} />
+      </>
+    );
+  }
+}
+
+export default DynamicInputForm;

--- a/__tests__/Element-spec.tsx
+++ b/__tests__/Element-spec.tsx
@@ -83,8 +83,8 @@ describe('Element', () => {
   it('should return true or false when calling isValid() depending on valid state', () => {
     let isValid = null;
     const Input = InputFactory({
-      componentWillReceiveProps: function(nextProps) {
-        isValid = nextProps.isValid;
+      componentDidUpdate: function() {
+        isValid = this.props.isValid;
       },
     });
     const form = mount(


### PR DESCRIPTION
# Description
Fix async tests that not used done and passed without a good reason :]

I will try to remove all tests warnings as there are many of them in future PRs