### PR TITLE
Edit validation function type to add string type (for error message)

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -11,7 +11,7 @@ export type IResetModel = (model?: IModel) => void;
 export type ISetInputValue = (name: string, value: Value, validate?: boolean) => void;
 export type IUpdateInputsWithError = (errors: any, invalidate?: boolean) => void;
 
-export type ValidationFunction = (values: Values, value: Value, extra?: any) => boolean;
+export type ValidationFunction = (values: Values, value: Value, extra?: any) => boolean | string;
 
 export type Validation = string | boolean | ValidationFunction;
 


### PR DESCRIPTION
Add string type to validation function to optionally return an error message in addition to a boolean state. 