### PR TITLE
Change form.setValue to form.updateInputsWithValue

### DIFF
--- a/API.md
+++ b/API.md
@@ -12,6 +12,7 @@
   - [preventExternalInvalidation](#preventExternalInvalidation)
   - [reset()](#reset)
   - [updateInputsWithError()](#updateInputsWithError)
+  - [updateInputsWithValue()](#setInputsWithValue)
   - [validationErrors](#validationErrors)
 - [withFormsy](#withFormsy)
   - [errorMessage](#errorMessage)
@@ -210,6 +211,25 @@ Manually set the form fields validation errors by taking an object that maps fie
 argument and optionally invalidate the form by passing `true` as the second argument. This is useful for server side
 validation. This is also passed as the third parameter to the [`onSubmit`](#onSubmit), [`onValidSubmit`](#onValid) or
 [`onInvalidSubmit`](#onInvalid).
+
+#### <a id="updateInputsWithValue">updateInputsWithValue(values)</a>
+
+```jsx
+class MyForm extends React.Component {
+  someFunction = () => {
+    this.refs.form.updateInputsWithValue({
+      email: 'value@example.com',
+      'field[10]': 'value!',
+    });
+  };
+  render() {
+    return <Formsy ref="form">...</Formsy>;
+  }
+}
+```
+
+Manually set the form fields values by taking an object that maps field name to value as the first argument and
+optionally validate the inputs by passing `true` as the second argument.
 
 #### <a id="preventExternalInvalidation">preventExternalInvalidation</a>
 

--- a/__tests__/Formsy-spec.tsx
+++ b/__tests__/Formsy-spec.tsx
@@ -543,7 +543,7 @@ describe('value === false', () => {
     expect(input.instance().getValue()).toEqual(true);
   });
 
-  it('should be able to set a value to one component with setValue', () => {
+  it('should be able to set a value to components with updateInputsWithValue', () => {
     class TestForm extends React.Component {
       state = {
         valueFoo: true,
@@ -576,7 +576,7 @@ describe('value === false', () => {
         .instance()
         .getValue(),
     ).toEqual(true);
-    formsyForm.instance().setValue('foo', false);
+    formsyForm.instance().updateInputsWithValue({ foo: false });
     expect(
       inputs
         .at(0)

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import {
   IUpdateInputsWithError,
   ValidationFunction,
 } from './interfaces';
-import { isString } from './utils';
 
 type FormHTMLAttributesCleaned = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onChange' | 'onSubmit'>;
 
@@ -411,7 +410,7 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
       const args = [
         {
           isValid: preventExternalInvalidation,
-          externalError: isString(error) ? [error] : error,
+          externalError: utils.isString(error) ? [error] : error,
         },
       ];
       component.setState(...args);

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,11 @@ import {
   IModel,
   InputComponent,
   IResetModel,
-  ISetInputValue,
+  IUpdateInputsWithValue,
   IUpdateInputsWithError,
   ValidationFunction,
 } from './interfaces';
+import { isString } from './utils';
 
 type FormHTMLAttributesCleaned = Omit<React.FormHTMLAttributes<HTMLFormElement>, 'onChange' | 'onSubmit'>;
 
@@ -297,14 +298,6 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
     this.validateForm();
   };
 
-  // Set the value of one component
-  public setValue: ISetInputValue<any> = (name, value, validate) => {
-    const input = this.inputs.find(component => component.props.name === name);
-    if (input) {
-      input.setValue(value, validate);
-    }
-  };
-
   // Checks validation on current value or a passed value
   public runValidation = <V>(component: InputComponent<V>, value = component.state.value) => {
     const { validationErrors } = this.props;
@@ -406,7 +399,7 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
     const { preventExternalInvalidation } = this.props;
     const { isValid } = this.state;
 
-    Object.keys(errors).forEach(name => {
+    Object.entries(errors).forEach(([name, error]) => {
       const component = this.inputs.find(input => input.props.name === name);
       if (!component) {
         throw new Error(
@@ -418,7 +411,7 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
       const args = [
         {
           isValid: preventExternalInvalidation,
-          externalError: typeof errors[name] === 'string' ? [errors[name]] : errors[name],
+          externalError: isString(error) ? [error] : error,
         },
       ];
       component.setState(...args);
@@ -426,6 +419,17 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
     if (invalidate && isValid) {
       this.setFormValidState(false);
     }
+  };
+
+  // Set the value of components
+  public updateInputsWithValue: IUpdateInputsWithValue<any> = (values, validate) => {
+    Object.entries(values).forEach(([name, value]) => {
+      const input = this.inputs.find(component => component.props.name === name);
+
+      if (input) {
+        input.setValue(value, validate);
+      }
+    });
   };
 
   // Use the binded values and the actual input value to

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,7 +8,7 @@ export interface Values {
 export type IModel = any;
 export type IData = any;
 export type IResetModel = (model?: IModel) => void;
-export type ISetInputValue<V> = (name: string, value: V, validate?: boolean) => void;
+export type IUpdateInputsWithValue<V> = (values: any, validate?: boolean) => void;
 export type IUpdateInputsWithError = (errors: any, invalidate?: boolean) => void;
 
 export type ValidationFunction<V> = (values: Values, value: V, extra?: any) => boolean | string;


### PR DESCRIPTION
# Description

As I was looking through the commits to make any changes necessary before releasing 2.x, I noticed we hadn't documented the new setValue. However, as I tried to document it, it became clear it was easily confused with `input.setValue` and not consistent with `updateInputsWithError`. This change preserves the functionality of the original, adds a bit more functionality, reduces confusion, and adds consistency.

**Original PR:** https://github.com/formsy/formsy-react/pull/189