### PR TITLE
Allow errors in UpdateInputsWithError method to be React elements

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,7 +8,7 @@ export interface Values {
 export type IModel = any;
 export type IResetModel = (model?: IModel) => void;
 export type IUpdateInputsWithValue<V> = (values: { [key: string]: V }, validate?: boolean) => void;
-export type IUpdateInputsWithError = (errors: { [key: string]: string }, invalidate?: boolean) => void;
+export type IUpdateInputsWithError = (errors: { [key: string]: ValidationError }, invalidate?: boolean) => void;
 
 export type ValidationError = string | React.ReactNode;
 


### PR DESCRIPTION
_( Assign ValidationError type to errors in updateInputsWithError method https://github.com/formsy/formsy-react/issues/455 )_

- [x] Title is human readable, as it will be included directly in `CHANGELOG.md` when we do a release
- [x] If this is a new user-facing feature, documentation has been added to `API.md`
- [x] Any `dist/` changes have not been committed.

Tests run directly on the source code and all dist changes are computed and committed during Formsy release.
