### PR TITLE
Add FormsyInjectedProps type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -481,6 +481,6 @@ const addValidationRule = <V>(name: string, func: ValidationFunction<V>) => {
   validationRules[name] = func;
 };
 
-export { addValidationRule, propTypes, validationRules, Wrapper as withFormsy };
+export { addValidationRule, propTypes, validationRules, Wrapper as withFormsy, PassDownProps as FormsyInjectedProps };
 
 export default Formsy;


### PR DESCRIPTION
This PR adds the type of injected props, so consumer that are using `withFormsy` as a class decorator will be able to add them manually.

- [x] Title is human readable, as it will be included directly in `CHANGELOG.md` when we do a release
- [x] If this is a new user-facing feature, documentation has been added to `API.md`
- [x] Any `dist/` changes have not been committed.

Tests run directly on the source code and all dist changes are computed and committed during Formsy release.
