### PR TITLE
fix: UMD version used in production build, closes #488

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
   "files": [
     "dist"
   ],
-  "browser": "dist/formsy-react.umd.js",
   "main": "dist/formsy-react.cjs.js",
   "module": "dist/formsy-react.esm.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR fixes #488 

- [x] Title is human readable, as it will be included directly in `CHANGELOG.md` when we do a release
- [x] If this is a new user-facing feature, documentation has been added to `API.md`
- [x] Any `dist/` changes have not been committed.

Tests run directly on the source code and all dist changes are computed and committed during Formsy release.
