### PR TITLE
Improve initial render

### DIFF
--- a/__test_utils__/expectIsValid.tsx
+++ b/__test_utils__/expectIsValid.tsx
@@ -24,7 +24,7 @@ function ValidationForm(props: { validations: string; value?: any }) {
 
 export function expectIsValid(testForm: React.ComponentElement<any, any>) {
   const form = mount(testForm);
-  const inputComponent = form.find(TestInput);
+  const inputComponent = form.find('Formsy(TestInput)');
   return expect(getWrapperInstance(inputComponent).isValid());
 }
 

--- a/__tests__/Element-spec.tsx
+++ b/__tests__/Element-spec.tsx
@@ -39,7 +39,7 @@ describe('Element', () => {
         <Input name="foo" value="foo" />
       </Formsy>,
     );
-    const inputComponent = form.find(Input);
+    const inputComponent = form.find('Formsy(NoValidateInput)');
     const setStateSpy = sinon.spy(getWrapperInstance(inputComponent), 'setState');
     const inputElement = form.find('input');
 
@@ -106,7 +106,7 @@ describe('Element', () => {
   it('should return true or false when calling isRequired() depending on passed required attribute', () => {
     const isRequireds = [];
     const Input = InputFactory({
-      componentDidUpdate() {
+      componentDidMount() {
         isRequireds.push(this.props.isRequired);
       },
     });
@@ -126,7 +126,7 @@ describe('Element', () => {
   it('should return true or false when calling showRequired() depending on input being empty and required is passed, or not', () => {
     const showRequireds = [];
     const Input = InputFactory({
-      componentDidUpdate() {
+      componentDidMount() {
         showRequireds.push(this.props.showRequired);
       },
     });
@@ -200,7 +200,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(input).isValidValue('foo@bar.com')).toEqual(true);
     expect(getWrapperInstance(input).isValidValue('foo@bar')).toEqual(false);
   });
@@ -221,7 +221,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(input).isValidValue('foo@bar.com')).toEqual(true);
     expect(getWrapperInstance(input).isValidValue('foo@bar')).toEqual(false);
   });
@@ -243,7 +243,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent).isValid()).toEqual(true);
     const input = form.find('input');
     input.simulate('change', { target: { value: 'bar' } });
@@ -282,7 +282,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent.at(0)).isValid()).toEqual(true);
     expect(getWrapperInstance(inputComponent.at(1)).isValid()).toEqual(true);
     const input = form.find('input');
@@ -310,7 +310,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent).getErrorMessage()).toEqual('bar3');
   });
 
@@ -339,7 +339,7 @@ describe('Element', () => {
     }
 
     const form = mount(<TestForm />);
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
 
     const formEl = form.find('form');
     formEl.simulate('submit');
@@ -367,7 +367,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent).getErrorMessage()).toEqual('bar');
   });
 
@@ -393,7 +393,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent).getErrorMessage()).toEqual('bar3');
   });
 
@@ -416,7 +416,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent).getErrorMessage()).toEqual('bar1');
   });
 
@@ -431,7 +431,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent).isValid()).toEqual(false);
   });
 
@@ -446,7 +446,7 @@ describe('Element', () => {
 
     const form = mount(<TestForm />);
 
-    const inputComponent = form.find(TestInput);
+    const inputComponent = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputComponent).isValid()).toEqual(false);
     expect(getWrapperInstance(inputComponent).getErrorMessage()).toEqual('Field is required');
   });
@@ -477,7 +477,7 @@ describe('Element', () => {
       bar: ['bar'],
     });
 
-    const inputs = form.find(TestInput);
+    const inputs = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(inputs.at(0)).getValue()).toEqual({ foo: 'foo' });
     expect(getWrapperInstance(inputs.at(1)).getValue()).toEqual(['bar']);
   });
@@ -507,7 +507,7 @@ describe('Element', () => {
     }
     const form = mount<TestForm>(<TestForm />);
 
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(input).isFormDisabled()).toEqual(true);
     form.instance().flip();
     expect(getWrapperInstance(input).isFormDisabled()).toEqual(false);

--- a/__tests__/Formsy-spec.tsx
+++ b/__tests__/Formsy-spec.tsx
@@ -434,7 +434,7 @@ describe('Update a form', () => {
     }
 
     const form = mount(<TestForm />);
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(input).isFormDisabled()).toEqual(true);
 
     (form.instance() as TestForm).enableForm();
@@ -466,7 +466,7 @@ describe('Update a form', () => {
 
     const form = mount(<TestForm />);
 
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(input).getErrorMessage()).toEqual('bar');
     getWrapperInstance(input).setValue('gotValue');
 
@@ -603,7 +603,7 @@ describe('value === false', () => {
     }
 
     const form = mount(<TestForm />);
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     expect(getWrapperInstance(input).isFormSubmitted()).toEqual(false);
     form.simulate('submit');
     expect(getWrapperInstance(input).isFormSubmitted()).toEqual(true);
@@ -635,7 +635,7 @@ describe('value === false', () => {
     }
 
     const form = mount(<TestForm />);
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     const formsyForm = form.find(Formsy);
     expect(getWrapperInstance(input).getValue()).toEqual(true);
     (form.instance() as TestForm).changeValue();
@@ -666,7 +666,7 @@ describe('value === false', () => {
     }
 
     const form = mount(<TestForm />);
-    const inputs = form.find(TestInput);
+    const inputs = form.find('Formsy(TestInput)');
     const formsyForm = form.find(Formsy);
     expect(getWrapperInstance(inputs.at(0)).getValue()).toEqual(true);
     expect(getWrapperInstance(inputs.at(1)).getValue()).toEqual(true);
@@ -706,8 +706,8 @@ describe('value === false', () => {
     }
 
     const form = mount(<TestForm />);
-    const input = form.find(TestInput).at(0);
-    const inputDeep = form.find(TestInput).at(1);
+    const input = form.find('Formsy(TestInput)').at(0);
+    const inputDeep = form.find('Formsy(TestInput)').at(1);
     const formsyForm = form.find(Formsy);
 
     expect(getWrapperInstance(input).getValue()).toEqual(1);
@@ -738,7 +738,7 @@ describe('.reset()', () => {
     }
 
     const form = mount(<TestForm />);
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     const formsyForm = form.find(Formsy);
 
     getFormInstance(formsyForm).reset({
@@ -758,7 +758,7 @@ describe('.reset()', () => {
     }
 
     const form = mount(<TestForm />);
-    const input = form.find(TestInput);
+    const input = form.find('Formsy(TestInput)');
     const formsyForm = form.find(Formsy);
 
     expect(getWrapperInstance(input).getValue()).toEqual('foo');

--- a/__tests__/Rules-equalsField-spec.tsx
+++ b/__tests__/Rules-equalsField-spec.tsx
@@ -17,7 +17,7 @@ function ValidationForm(props: { validations: string; value?: any; other?: any }
 
 export function expectIsValid(testForm: React.ComponentElement<any, any>) {
   const form = mount(testForm);
-  const inputComponent = form.find(TestInput).first();
+  const inputComponent = form.find('Formsy(TestInput)').first();
   return expect(inputComponent.instance().isValid());
 }
 

--- a/__tests__/Validation-spec.tsx
+++ b/__tests__/Validation-spec.tsx
@@ -33,7 +33,7 @@ describe('Validation', () => {
     );
 
     const input = form.find('input').at(0);
-    const inputComponents = form.find(FormsyTest);
+    const inputComponents = form.find('Formsy(MyTest)');
 
     getFormInstance(form).submit();
     expect(getWrapperInstance(inputComponents.at(0)).isValid()).toEqual(false);
@@ -54,7 +54,7 @@ describe('Validation', () => {
     );
 
     const input = form.find('input');
-    const inputComponent = form.find(FormsyTest);
+    const inputComponent = form.find('Formsy(MyTest)');
 
     getFormInstance(form).submit();
     expect(getWrapperInstance(inputComponent).isValid()).toEqual(false);
@@ -136,7 +136,7 @@ describe('Validation', () => {
     const form = mount(<TestForm />);
 
     const formEl = form.find('form');
-    const input = form.find(FormsyTest);
+    const input = form.find('Formsy(MyTest)');
     formEl.simulate('submit');
     expect(getWrapperInstance(input).isValid()).toEqual(false);
   });
@@ -152,7 +152,7 @@ describe('Validation', () => {
 
     const form = mount(<TestForm />);
     const formEl = form.find('form');
-    const input = form.find(FormsyTest);
+    const input = form.find('Formsy(MyTest)');
     formEl.simulate('submit');
     expect(getWrapperInstance(input).getErrorMessage()).toEqual('bar');
   });
@@ -168,7 +168,7 @@ describe('Validation', () => {
 
     const form = mount(<TestForm />);
     const formEl = form.find('form');
-    const input = form.find(FormsyTest);
+    const input = form.find('Formsy(MyTest)');
     formEl.simulate('submit');
     expect(getWrapperInstance(input).isValid()).toEqual(true);
   });
@@ -184,7 +184,7 @@ describe('Validation', () => {
 
     const form = mount(<TestForm />);
     const formEl = form.find('form');
-    const input = form.find(FormsyTest);
+    const input = form.find('Formsy(MyTest)');
     formEl.simulate('submit');
     expect(getWrapperInstance(input).isValid()).toEqual(false);
   });

--- a/src/FormsyContext.ts
+++ b/src/FormsyContext.ts
@@ -14,6 +14,7 @@ const defaultValue = {
   isFormDisabled: true,
   isValidValue: throwNoFormsyProvider,
   validate: throwNoFormsyProvider,
+  runValidation: throwNoFormsyProvider,
 };
 
 export default React.createContext<FormsyContextInterface>(defaultValue);

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import set from 'lodash.set';
 
 import * as utils from './utils';
 import validationRules from './validationRules';
-import Wrapper, { PassDownProps, propTypes, WrapperState } from './Wrapper';
+import Wrapper, { PassDownProps, propTypes } from './Wrapper';
 import FormsyContext from './FormsyContext';
 
 import {
@@ -16,6 +16,7 @@ import {
   IResetModel,
   IUpdateInputsWithError,
   IUpdateInputsWithValue,
+  ValidationError,
   ValidationFunction,
 } from './interfaces';
 import { isObject, isString } from './utils';
@@ -98,6 +99,7 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
         isFormDisabled: props.disabled,
         isValidValue: this.isValidValue,
         validate: this.validate,
+        runValidation: this.runValidation,
       },
     };
     this.inputs = [];
@@ -254,7 +256,10 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
   };
 
   // Checks validation on current value or a passed value
-  public runValidation = <V>(component: InputComponent<V>, value = component.state.value): Partial<WrapperState<V>> => {
+  public runValidation = <V>(
+    component: InputComponent<V>,
+    value = component.state.value,
+  ): { isRequired: boolean; isValid: boolean; validationError: ValidationError[] } => {
     const { validationErrors } = this.props;
     const { validationError, validationErrors: componentValidationErrors, name } = component.props;
     const currentValues = this.getCurrentValues();
@@ -304,7 +309,13 @@ class Formsy extends React.Component<FormsyProps, FormsyState> {
       this.inputs.push(component);
     }
 
-    this.validate(component);
+    const { onChange } = this.props;
+    const { canChange } = this.state;
+
+    // Trigger onChange
+    if (canChange) {
+      onChange(this.getModel(), this.isChanged());
+    }
   };
 
   // Method put on each input component to unregister

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -40,4 +40,7 @@ export interface FormsyContextInterface {
   isFormDisabled: boolean;
   isValidValue: (component: InputComponent<any>, value: any) => boolean;
   validate: (component: InputComponent<any>) => void;
+  runValidation: (
+    component: InputComponent<any>,
+  ) => { isRequired: boolean; isValid: boolean; validationError: ValidationError[] };
 }


### PR DESCRIPTION
This PR improves initial render by preventing "setState" from the Form component to the InputWrapper.

Technical explanation, I've noticed that each time an Input component get mounted it calls to `attachToForm` which does some state calculation and then **sets** the input state again, which causes another re-render.

What I've done:
1. Expose Input state calculation method on the Form context (runValidation).
2. Since context is not available in Class component **constructor**, I've wrapped the InputWrapper with Context.Consumer, and pass it as props.
3. Run `runValidation` in the input constructor (=> no need to run it on `attachToForm`), it returns a validation related state values, assign it to InputWrapper initial state.
4. Keep calling `attachToForm` from `componentDidMount` lifecycle method (since the from runs entire formValidate method which required Input to be mounted)
5. Remove call to `validate` from `attachToForm` implementation (since it is already calculated at the constructor).

Pay attention that I've needed to change selectors in the tests due to additional wrapper for the InputWrapper (to gain access to the context).

There were 2 tests that relied on the fact that the input re-rendered (componentDidUpdate), now they are not re-renders :] 

Before:
![image](https://user-images.githubusercontent.com/9304194/84573560-fe8db700-ada9-11ea-8a7a-31b9f1cdeeda.png)

After:
![image](https://user-images.githubusercontent.com/9304194/84573579-1e24df80-adaa-11ea-88b7-034033349ac1.png)


You can play with a test from here: https://github.com/felixmosh/formsy-react-improved-initial-render-test, add `?improved` to the page in order to render with the improved version
- [x] Title is human readable, as it will be included directly in `CHANGELOG.md` when we do a release
- [x] If this is a new user-facing feature, documentation has been added to `API.md`
- [x] Any `dist/` changes have not been committed.


Related to #471 