### PR TITLE
Add "formElement" props to allow any element to be render as a form 

### DIFF
--- a/API.md
+++ b/API.md
@@ -17,6 +17,7 @@
   - [updateInputsWithError()](#updateInputsWithError)
   - [updateInputsWithValue()](#updateInputsWithValue)
   - [validationErrors](#validationErrors)
+  - [as](#as)
 - [withFormsy](#withFormsy)
   - [errorMessage](#errorMessage)
   - [errorMessages](#errorMessages)
@@ -292,6 +293,20 @@ class MyForm extends React.Component {
 
 With the `preventExternalInvalidation` the input will not be invalidated though it has an error when
 `updateInputsWithError()` or an `invalidate` callback is called.
+
+### <a id="as">as</a>
+By default Formy render the form with the HTML `form` element.
+If you want to override this behaviour, you can pass the element to render in the `as` props
+
+```jsx
+  <Formsy as="div">
+    ...
+  </Formsy>
+
+  <Formsy as={MyCustomFormElement}>
+    ...
+  </Formsy>
+```
 
 ### <a id="withFormsy">`withFormsy`</a>
 

--- a/API.md
+++ b/API.md
@@ -17,7 +17,7 @@
   - [updateInputsWithError()](#updateInputsWithError)
   - [updateInputsWithValue()](#updateInputsWithValue)
   - [validationErrors](#validationErrors)
-  - [as](#as)
+  - [formElement](#formElement)
 - [withFormsy](#withFormsy)
   - [errorMessage](#errorMessage)
   - [errorMessages](#errorMessages)
@@ -294,16 +294,16 @@ class MyForm extends React.Component {
 With the `preventExternalInvalidation` the input will not be invalidated though it has an error when
 `updateInputsWithError()` or an `invalidate` callback is called.
 
-### <a id="as">as</a>
-By default Formy render the form with the HTML `form` element.
-If you want to override this behaviour, you can pass the element to render in the `as` props
+### <a id="formElement">formElement</a>
+By default Formsy render the form with the HTML `form` element.
+If you want to override this behaviour, you can pass the element to render in the `formElement` props
 
 ```jsx
-  <Formsy as="div">
+  <Formsy formElement="div">
     ...
   </Formsy>
 
-  <Formsy as={MyCustomFormElement}>
+  <Formsy formElement={MyCustomFormElement}>
     ...
   </Formsy>
 ```

--- a/__tests__/Formsy.spec.tsx
+++ b/__tests__/Formsy.spec.tsx
@@ -1053,14 +1053,14 @@ describe('onSubmit/onValidSubmit/onInvalidSubmit', () => {
 describe('<Formsy /> can render any tag or element with the props as', () => {
   it('as div', () => {
     const form = mount(
-      <Formsy as="div" />
+      <Formsy formElement="div" />
     );
     expect(form.find('div').length).toBe(1)
   })
   it('as CustumElement', () => {
     const CustomElement = ({ children }) => <div>{children}</div>;
     const form = mount(
-      <Formsy as={CustomElement} />
+      <Formsy formElement={CustomElement} />
     );
     expect(form.find(CustomElement).length).toBe(1)
   })

--- a/__tests__/Formsy.spec.tsx
+++ b/__tests__/Formsy.spec.tsx
@@ -1049,3 +1049,19 @@ describe('onSubmit/onValidSubmit/onInvalidSubmit', () => {
     });
   });
 });
+
+describe('<Formsy /> can render any tag or element with the props as', () => {
+  it('as div', () => {
+    const form = mount(
+      <Formsy as="div" />
+    );
+    expect(form.find('div').length).toBe(1)
+  })
+  it('as CustumElement', () => {
+    const CustomElement = ({ children }) => <div>{children}</div>;
+    const form = mount(
+      <Formsy as={CustomElement} />
+    );
+    expect(form.find(CustomElement).length).toBe(1)
+  })
+})

--- a/src/Formsy.ts
+++ b/src/Formsy.ts
@@ -28,7 +28,7 @@ type OnSubmitCallback = (
   event: React.SyntheticEvent<React.FormHTMLAttributes<any>>,
 ) => void;
 
-type AsType =
+type FormElementType =
   | string
   | React.ComponentType<{
       onReset?: (e: React.SyntheticEvent) => void;
@@ -50,7 +50,7 @@ export interface FormsyProps extends FormHTMLAttributesCleaned {
   preventDefaultSubmit?: boolean;
   preventExternalInvalidation?: boolean;
   validationErrors?: null | object;
-  as?: AsType;
+  formElement?: FormElementType;
 }
 
 export interface FormsyState {
@@ -76,7 +76,7 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
   public static propTypes = {
     disabled: PropTypes.bool,
     mapping: PropTypes.func,
-    as: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
+    formElement: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
     onChange: PropTypes.func,
     onInvalid: PropTypes.func,
     onInvalidSubmit: PropTypes.func,
@@ -102,7 +102,7 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
     preventDefaultSubmit: true,
     preventExternalInvalidation: false,
     validationErrors: {},
-    as: 'form',
+    formElement: 'form',
   };
 
   private readonly throttledValidateForm: () => void;
@@ -489,7 +489,7 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
       preventExternalInvalidation,
       validationErrors,
       disabled,
-      as,
+      formElement,
       ...nonFormsyProps
     } = this.props;
     const { contextValue } = this.state;
@@ -500,7 +500,7 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
         value: contextValue,
       },
       React.createElement(
-        as,
+        formElement,
         {
           onReset: this.resetInternal,
           onSubmit: this.submit,

--- a/src/Formsy.ts
+++ b/src/Formsy.ts
@@ -28,6 +28,15 @@ type OnSubmitCallback = (
   event: React.SyntheticEvent<React.FormHTMLAttributes<any>>,
 ) => void;
 
+type AsType =
+  | string
+  | React.ComponentType<{
+      onReset?: (e: React.SyntheticEvent) => void;
+      onSubmit?: (e: React.SyntheticEvent) => void;
+      disabled?: boolean;
+      children?: React.ReactChildren;
+    }>;
+
 export interface FormsyProps extends FormHTMLAttributesCleaned {
   disabled: boolean;
   mapping: null | ((model: IModel) => IModel);
@@ -41,6 +50,7 @@ export interface FormsyProps extends FormHTMLAttributesCleaned {
   preventDefaultSubmit?: boolean;
   preventExternalInvalidation?: boolean;
   validationErrors?: null | object;
+  as?: AsType;
 }
 
 export interface FormsyState {
@@ -66,6 +76,7 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
   public static propTypes = {
     disabled: PropTypes.bool,
     mapping: PropTypes.func,
+    as: PropTypes.oneOfType([PropTypes.string, PropTypes.object, PropTypes.func]),
     onChange: PropTypes.func,
     onInvalid: PropTypes.func,
     onInvalidSubmit: PropTypes.func,
@@ -91,6 +102,7 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
     preventDefaultSubmit: true,
     preventExternalInvalidation: false,
     validationErrors: {},
+    as: 'form',
   };
 
   private readonly throttledValidateForm: () => void;
@@ -476,7 +488,8 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
       preventDefaultSubmit,
       preventExternalInvalidation,
       validationErrors,
-      /* eslint-enable @typescript-eslint/no-unused-vars */
+      disabled,
+      as,
       ...nonFormsyProps
     } = this.props;
     const { contextValue } = this.state;
@@ -487,12 +500,12 @@ export class Formsy extends React.Component<FormsyProps, FormsyState> {
         value: contextValue,
       },
       React.createElement(
-        'form',
+        as,
         {
           onReset: this.resetInternal,
           onSubmit: this.submit,
           ...nonFormsyProps,
-          disabled: false,
+          disabled,
         },
         children,
       ),


### PR DESCRIPTION
_( Allow overriding the element to render as form )_

- [x] Title is human readable, as it will be included directly in CHANGELOG.md when we do a release
- [x] If this is a new user-facing feature, documentation has been added to API.md
- [x] Any dist/ changes have not been committed.

Tests run directly on the source code and all dist changes are computed and committed during Formsy release.

```jsx
  <Formsy as="div">
    ...
  </Formsy>

  <Formsy as={MyCustomFormElement}>
    ...
  </Formsy>
```