### PR TITLE
Add react 17 as valid peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,8 @@
     "typescript": "^3.9.7"
   },
   "peerDependencies": {
-    "react": "^16.0.0",
-    "react-dom": "^16.0.0"
+    "react": "^16.0.0 || ^17.0.0",
+    "react-dom": "^16.0.0 || ^17.0.0"
   },
   "standard-version": {
     "skip": {


### PR DESCRIPTION
This PR adds React 17 as valid peer deps

- [x] Title is human readable, as it will be included directly in `CHANGELOG.md` when we do a release
- [x] If this is a new user-facing feature, documentation has been added to `API.md`
- [x] Any `dist/` changes have not been committed.

Tests run directly on the source code and all dist changes are computed and committed during Formsy release.
