### PR TITLE
fix: export WrapperProps to fix TS2883 with declaration emit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { addValidationRule, validationRules } from './validationRules';
-import { withFormsy, type PassDownProps, type InjectedProps } from './withFormsy';
+import { withFormsy, type PassDownProps, type InjectedProps, type WrapperProps } from './withFormsy';
 import { Formsy } from './Formsy';
 
 export { withFormsy };
-export type { PassDownProps as FormsyInjectedProps, InjectedProps };
+export type { PassDownProps as FormsyInjectedProps, InjectedProps, WrapperProps };
 export default Formsy;


### PR DESCRIPTION
Fixes #759

## What

Export `WrapperProps` from the main `formsy-react` entry point.

```diff
- export type { PassDownProps as FormsyInjectedProps, InjectedProps };
+ export type { PassDownProps as FormsyInjectedProps, InjectedProps, WrapperProps };
```

## Why

The return type of `withFormsy<T, V>` is:

```ts
React.ComponentType<Omit<T & WrapperProps<V>, keyof InjectedProps<V>>>
```

When a project has `declaration: true` (or `composite: true`) in tsconfig, TypeScript must write this type into the generated `.d.ts` file. Because `WrapperProps` is only reachable via the internal `dist/withFormsy` path and not the main entry, TypeScript raises **TS2883** on every exported component:

```
error TS2883: The inferred type of 'MyInput' cannot be named without a reference to
'WrapperProps' from '../../node_modules/formsy-react/dist/withFormsy'.
This is likely not portable. A type annotation is necessary.
```

Exporting `WrapperProps` from the main entry gives TypeScript a portable name to reference, eliminating the error without any changes required in consumer code.

## Impact

- **Non-breaking**: purely additive type export.
- **No runtime change**: type-only export, zero JS output diff.
- `WrapperProps` is already part of the implicit public API (it describes exactly what every consumer must pass to a `withFormsy`-wrapped component); making it explicit is an improvement.
