### PR TITLE
Do not call setState after unmount in validateForm function

### DIFF
--- a/src/Formsy.ts
+++ b/src/Formsy.ts
@@ -101,7 +101,7 @@ export class Formsy extends React.Component<PropsWithChildren<FormsyProps>, Form
 
   public componentWillUnmount = () => {
     this.mounted = false;
-  }
+  };
 
   public componentDidUpdate = (prevProps: FormsyProps) => {
     const { validationErrors, disabled = false } = this.props;

--- a/src/Formsy.ts
+++ b/src/Formsy.ts
@@ -67,6 +67,7 @@ export class Formsy extends React.Component<PropsWithChildren<FormsyProps>, Form
   public emptyArray: any[];
   public prevInputNames: any[] | null = null;
   private readonly debouncedValidateForm: () => void;
+  private mounted: boolean = false;
 
   public constructor(props: FormsyProps) {
     super(props);
@@ -85,13 +86,22 @@ export class Formsy extends React.Component<PropsWithChildren<FormsyProps>, Form
     };
     this.inputs = [];
     this.emptyArray = [];
-    this.debouncedValidateForm = debounce(this.validateForm, ONE_RENDER_FRAME);
+    this.debouncedValidateForm = debounce(() => {
+      if (this.mounted) {
+        this.validateForm();
+      }
+    }, ONE_RENDER_FRAME);
   }
 
   public componentDidMount = () => {
+    this.mounted = true;
     this.prevInputNames = this.inputs.map((component) => component.props.name);
     this.validateForm();
   };
+
+  public componentWillUnmount = () => {
+    this.mounted = false;
+  }
 
   public componentDidUpdate = (prevProps: FormsyProps) => {
     const { validationErrors, disabled = false } = this.props;


### PR DESCRIPTION
_Avoid calling setState after component unmount_

- [x] Title is human readable, as it will be included directly in `CHANGELOG.md` when we do a release
- [x] If this is a new user-facing feature, documentation has been added to `API.md`
- [x] Any `dist/` changes have not been committed.

Tests run directly on the source code and all dist changes are computed and committed during Formsy release.